### PR TITLE
Specify JSON content type for SQL API

### DIFF
--- a/app/Palacinkyy/api/sql.js
+++ b/app/Palacinkyy/api/sql.js
@@ -14,7 +14,11 @@ export async function sql(sql) {
   });
 
   try {
-    const response = await fetch(url, { method: "POST", body: postJson });
+    const response = await fetch(url, {
+      method: "POST",
+      body: postJson,
+      headers: { "Content-Type": "application/json" },
+    });
     if (!response.ok) {
       throw new Error(`Response status: ${response.status}`);
     }


### PR DESCRIPTION
## Summary
- add `Content-Type: application/json` header to SQL API requests so server parses payload

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9d60954bc8322bfd51493de125bcb