### PR TITLE
Persist recipes using cookies and handle image URLs

### DIFF
--- a/app/Palacinkyy/api/palacinky.js
+++ b/app/Palacinkyy/api/palacinky.js
@@ -1,20 +1,50 @@
-// Simple in-memory store for recipes. This replaces the previous
-// database-backed implementation so that the application works without
-// any external dependencies.
+import { createCookie } from "@remix-run/node";
 
-/** @type {{ id: number; kategorie: string; img: string; popis: string }[]} */
-let data = [];
+// Cookie used to persist recipes on the client. The cookie is accessible on all
+// routes of the application.
+export const palacinkyCookie = createCookie("palacinky", {
+  path: "/",
+});
 
-export async function getList() {
-  // Return only the basic fields used on the index page.
+/**
+ * Internal helper that reads the recipe list from the cookie. Always returns an
+ * array to simplify callers.
+ * @param {Request} request
+ */
+async function readData(request) {
+  const cookieHeader = request.headers.get("Cookie");
+  const data = await palacinkyCookie.parse(cookieHeader);
+  return Array.isArray(data) ? data : [];
+}
+
+/**
+ * Returns only the fields required for the index page.
+ * @param {Request} request
+ */
+export async function getList(request) {
+  const data = await readData(request);
   return data.map(({ id, kategorie, img }) => ({ id, kategorie, img }));
 }
 
-export async function insertRecipe({ kategorie, img, popis }) {
+/**
+ * Inserts a new recipe into the cookie and returns a serialized Set-Cookie
+ * header value that should be sent in the response.
+ * @param {Request} request
+ * @param {{ kategorie: string; img: string; popis: string }} recipe
+ */
+export async function insertRecipe(request, { kategorie, img, popis }) {
+  const data = await readData(request);
   const id = data.length > 0 ? data[data.length - 1].id + 1 : 1;
   data.push({ id, kategorie, img, popis });
+  return palacinkyCookie.serialize(data);
 }
 
-export async function getById(id) {
+/**
+ * Retrieves a single recipe by id from the cookie store.
+ * @param {Request} request
+ * @param {number|string} id
+ */
+export async function getById(request, id) {
+  const data = await readData(request);
   return data.find((item) => item.id === Number(id));
 }

--- a/app/routes/_index.jsx
+++ b/app/routes/_index.jsx
@@ -9,18 +9,19 @@ export const meta = () => {
   return [{ title: "Palacinky" }, { name: "description", content: "Palacinky" }];
 };
 
-export async function loader() {
-  let list = await getList();
+export async function loader({ request }) {
+  let list = await getList(request);
   return list;
 }
 
 export async function action({ request }) {
   const formData = await request.formData();
-  const kategorie = formData.get("kategorie");
-  const img = formData.get("img");
+  const kategorie = formData.get("kategorie")?.trim();
+  const img = formData.get("img")?.trim();
   const popis = formData.get("popis");
   if (kategorie && img) {
-    await insertRecipe({ kategorie, img, popis });
+    const cookie = await insertRecipe(request, { kategorie, img, popis });
+    return redirect("/", { headers: { "Set-Cookie": cookie } });
   }
   return redirect("/");
 }

--- a/app/routes/recept.$id.jsx
+++ b/app/routes/recept.$id.jsx
@@ -1,8 +1,8 @@
 import { useLoaderData } from "@remix-run/react";
 import { getById } from "../Palacinkyy/api/palacinky";
 
-export async function loader({ params }) {
-  const recept = await getById(params.id);
+export async function loader({ params, request }) {
+  const recept = await getById(request, params.id);
   if (!recept) {
     throw new Response("Not Found", { status: 404 });
   }


### PR DESCRIPTION
## Summary
- store recipes in a cookie to keep entries after closing the page
- trim and accept image URLs when adding new recipes
- load recipes from cookie in detail route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9d80a32308322ac95ea05445085c8