### PR TITLE
Add edit and delete buttons for recipes

### DIFF
--- a/app/Palacinkyy/api/palacinky.js
+++ b/app/Palacinkyy/api/palacinky.js
@@ -23,7 +23,12 @@ async function readData(request) {
  */
 export async function getList(request) {
   const data = await readData(request);
-  return data.map(({ id, kategorie, img }) => ({ id, kategorie, img }));
+  return data.map(({ id, kategorie, img, popis }) => ({
+    id,
+    kategorie,
+    img,
+    popis,
+  }));
 }
 
 /**
@@ -47,4 +52,30 @@ export async function insertRecipe(request, { kategorie, img, popis }) {
 export async function getById(request, id) {
   const data = await readData(request);
   return data.find((item) => item.id === Number(id));
+}
+
+/**
+ * Deletes a recipe by id and returns a serialized Set-Cookie header value.
+ * @param {Request} request
+ * @param {number|string} id
+ */
+export async function deleteRecipe(request, id) {
+  const data = await readData(request);
+  const filtered = data.filter((item) => item.id !== Number(id));
+  return palacinkyCookie.serialize(filtered);
+}
+
+/**
+ * Updates an existing recipe in the cookie store and returns a serialized
+ * Set-Cookie header value.
+ * @param {Request} request
+ * @param {{ id: number; kategorie: string; img: string; popis: string }} recipe
+ */
+export async function updateRecipe(request, { id, kategorie, img, popis }) {
+  const data = await readData(request);
+  const index = data.findIndex((item) => item.id === Number(id));
+  if (index >= 0) {
+    data[index] = { ...data[index], kategorie, img, popis };
+  }
+  return palacinkyCookie.serialize(data);
 }

--- a/app/Palacinkyy/article.jsx
+++ b/app/Palacinkyy/article.jsx
@@ -1,15 +1,31 @@
-import { Link } from "@remix-run/react";
+import { Link, Form } from "@remix-run/react";
 
 /**
  * @param {number} id
  * @param {string} city
  * @param {string} img
+ * @param {string} [popis]
  */
-export default function Article({ id, city, img }) {
+export default function Article({ id, city, img, popis }) {
   return (
     <article>
       <Link to={`/recept/${id}`}><h1>{city}</h1></Link>
       <img src={img} alt={city} />
+      <Form method="post">
+        <input type="hidden" name="id" value={id} />
+        <button type="submit" name="_action" value="delete">
+          Smazat
+        </button>
+      </Form>
+      <Form method="post">
+        <input type="hidden" name="id" value={id} />
+        <input name="kategorie" defaultValue={city} />
+        <input name="img" defaultValue={img} />
+        <input name="popis" defaultValue={popis || ""} />
+        <button type="submit" name="_action" value="edit">
+          Upravit
+        </button>
+      </Form>
     </article>
   );
 }

--- a/app/Palacinkyy/main.jsx
+++ b/app/Palacinkyy/main.jsx
@@ -14,6 +14,7 @@ export default function Main({ list }) {
           id={palacinky.id}
           city={palacinky.kategorie}
           img={palacinky.img}
+          popis={palacinky.popis}
         />
       ))}
     </section>

--- a/app/routes/_index.jsx
+++ b/app/routes/_index.jsx
@@ -1,7 +1,12 @@
 import Header from "../Palacinkyy/header.jsx";
 import Main from "../Palacinkyy/main.jsx";
 import { Form, useLoaderData } from "@remix-run/react";
-import { getList, insertRecipe } from "../Palacinkyy/api/palacinky";
+import {
+  getList,
+  insertRecipe,
+  deleteRecipe,
+  updateRecipe,
+} from "../Palacinkyy/api/palacinky";
 import { redirect } from "@remix-run/node";
 
 
@@ -16,6 +21,31 @@ export async function loader({ request }) {
 
 export async function action({ request }) {
   const formData = await request.formData();
+  const intent = formData.get("_action");
+  if (intent === "delete") {
+    const id = formData.get("id");
+    if (id) {
+      const cookie = await deleteRecipe(request, id);
+      return redirect("/", { headers: { "Set-Cookie": cookie } });
+    }
+    return redirect("/");
+  }
+  if (intent === "edit") {
+    const id = formData.get("id");
+    const kategorie = formData.get("kategorie")?.trim();
+    const img = formData.get("img")?.trim();
+    const popis = formData.get("popis");
+    if (id && kategorie && img) {
+      const cookie = await updateRecipe(request, {
+        id: Number(id),
+        kategorie,
+        img,
+        popis,
+      });
+      return redirect("/", { headers: { "Set-Cookie": cookie } });
+    }
+    return redirect("/");
+  }
   const kategorie = formData.get("kategorie")?.trim();
   const img = formData.get("img")?.trim();
   const popis = formData.get("popis");
@@ -36,7 +66,7 @@ export default function Index() {
         <input name="kategorie" placeholder="Název" />
         <input name="img" placeholder="URL obrázku" />
         <input name="popis" placeholder="Popis" />
-        <button type="submit">Přidat</button>
+        <button type="submit" name="_action" value="create">Přidat</button>
       </Form>
       <Main list={list} />
     </>


### PR DESCRIPTION
## Summary
- add inline forms for editing and deleting recipes
- extend API with delete and update helpers
- handle new actions on index page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a9d92022a88322bb06f8c67e8a94f2