### PR TITLE
feat: style blog list and header

### DIFF
--- a/app/components/Blog.tsx
+++ b/app/components/Blog.tsx
@@ -4,6 +4,7 @@ import { Link } from '@remix-run/react';
 export interface PostListItem {
   id: number;
   title: string;
+  created_at: string;
 }
 
 interface BlogProps {
@@ -13,13 +14,16 @@ interface BlogProps {
 export default function Blog({ posts }: BlogProps) {
   return (
     <main>
-      <ul>
+      <section>
         {posts.map((post) => (
-          <li key={post.id}>
-            <Link to={`/posts/${post.id}`}>{post.title}</Link>
-          </li>
+          <article key={post.id}>
+            <h2>
+              <Link to={`/posts/${post.id}`}>{post.title}</Link>
+            </h2>
+            <p>{new Date(post.created_at).toLocaleDateString()}</p>
+          </article>
         ))}
-      </ul>
+      </section>
     </main>
   );
 }

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import { Link } from '@remix-run/react';
 
 export default function Header() {
   return (
     <header>
       <h1>Blog</h1>
+      <nav>
+        <Link to="/">Home</Link>
+      </nav>
     </header>
   );
 }

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -15,7 +15,11 @@ export async function getPosts() {
     'SELECT id, title, created_at FROM posts ORDER BY created_at DESC'
   );
   await conn.end();
-  return rows as { id: number; title: string; created_at: Date }[];
+  const posts = rows as { id: number; title: string; created_at: Date }[];
+  return posts.map((post) => ({
+    ...post,
+    created_at: post.created_at.toISOString(),
+  }));
 }
 
 export async function getPost(id: number) {
@@ -31,5 +35,11 @@ export async function getPost(id: number) {
     content: string;
     created_at: Date;
   }[];
-  return posts[0];
+  const post = posts[0];
+  return post
+    ? {
+        ...post,
+        created_at: post.created_at.toISOString(),
+      }
+    : undefined;
 }


### PR DESCRIPTION
## Summary
- style blog list and show post dates
- add simple navigation in header
- return ISO strings for post dates from database

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac22ecf03c832298f8d5e80dfd07f8