### PR TITLE
Add comment functionality to blog posts

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -33,3 +33,22 @@ export async function getPost(id: number) {
   }[];
   return posts[0];
 }
+
+export async function getComments(postId: number) {
+  const conn = await getConnection();
+  const [rows] = await conn.query(
+    'SELECT id, content, created_at FROM comments WHERE post_id = ? ORDER BY created_at DESC',
+    [postId]
+  );
+  await conn.end();
+  return rows as { id: number; content: string; created_at: Date }[];
+}
+
+export async function addComment(postId: number, content: string) {
+  const conn = await getConnection();
+  await conn.query(
+    'INSERT INTO comments (post_id, content) VALUES (?, ?)',
+    [postId, content]
+  );
+  await conn.end();
+}

--- a/app/routes/item.tsx
+++ b/app/routes/item.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
-import { getPost } from '../db.server';
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+import { Form, useLoaderData } from '@remix-run/react';
+import { addComment, getComments, getPost } from '../db.server';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
@@ -13,16 +14,47 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (!post) {
     throw new Response('Not Found', { status: 404 });
   }
-  return post;
+  const comments = await getComments(id);
+  return { post, comments };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const idParam = formData.get('postId');
+  const content = formData.get('content');
+  const id = typeof idParam === 'string' ? Number(idParam) : NaN;
+  if (typeof content !== 'string' || isNaN(id)) {
+    return new Response('Bad Request', { status: 400 });
+  }
+  await addComment(id, content);
+  return redirect(`/item?id=${id}`);
 }
 
 export default function ItemRoute() {
-  const post = useLoaderData<typeof loader>();
+  const { post, comments } = useLoaderData<typeof loader>();
   return (
-    <article>
-      <h2>{post.title}</h2>
-      <p>{new Date(post.created_at).toLocaleDateString()}</p>
-      <div>{post.content}</div>
-    </article>
+    <div>
+      <article>
+        <h2>{post.title}</h2>
+        <p>{new Date(post.created_at).toLocaleDateString()}</p>
+        <div>{post.content}</div>
+      </article>
+      <section>
+        <h3>Comments</h3>
+        <ul>
+          {comments.map((comment) => (
+            <li key={comment.id}>
+              <p>{comment.content}</p>
+              <p>{new Date(comment.created_at).toLocaleString()}</p>
+            </li>
+          ))}
+        </ul>
+        <Form method="post">
+          <input type="hidden" name="postId" value={post.id} />
+          <textarea name="content" />
+          <button type="submit">Add Comment</button>
+        </Form>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow adding and viewing comments on individual blog posts
- persist comments in database

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b20a0b607083228c0549e634f4eb1c